### PR TITLE
Added minimal support for TV Season API endpoint

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ refreshes every day.
         print(p.title)
         print(p.overview)
         print(p.poster_path)
-                
+
 
 Get the primary information about a movie.
 
@@ -128,6 +128,15 @@ Get the similar TV shows for a specific tv id.
     for show in similar:
         print(show.name)
         print(show.overview)
+
+Get the details of TV season for a specific tv id.
+
+.. code:: python
+
+    season = Season()
+    show_season = season.details(1396, 1)
+    print(show_season.air_date)
+    print(len(show_season.episodes))
 
 Get the general person information for a specific id.
 
@@ -185,6 +194,7 @@ of votes, genres, the network they aired on and air dates.
         'sort_by': 'vote_average.desc',
         'vote_count.gte': 10
     })
+
 
 Running Tests
 ~~~~~~~~~~~~~

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3,7 +3,7 @@
 import unittest
 import os
 import math
-from tmdbv3api import TMDb, Movie, Discover, TV, Person, Collection, Company, Configuration, Genre
+from tmdbv3api import TMDb, Movie, Discover, TV, Person, Collection, Company, Configuration, Genre, Season
 
 
 class TMDbTests(unittest.TestCase):
@@ -16,6 +16,7 @@ class TMDbTests(unittest.TestCase):
         self.person = Person()
         self.collection = Collection()
         self.company = Company()
+        self.season = Season()
 
     def test_get_movie(self):
         movie = self.movie.details(111)
@@ -215,3 +216,16 @@ class TMDbTests(unittest.TestCase):
         self.assertIsNotNone(movie_genres)
         tv_genres = genres.tv_list()
         self.assertIsNotNone(tv_genres)
+
+    def test_season(self):
+        s = self.season.details(1418, 1)
+        self.assertIsNotNone(s)
+        self.assertEqual(s.name, 'Season 1')
+        self.assertEqual(s.id, 3738)
+        self.assertTrue(hasattr(s, 'episodes'))
+        self.assertTrue(hasattr(s, 'overview'))
+        self.assertTrue(hasattr(s, 'id'))
+
+    def test_get_season_changes(self):
+        s = self.season.changes(1418, 1)
+        self.assertIsNotNone(s)

--- a/tmdbv3api/__init__.py
+++ b/tmdbv3api/__init__.py
@@ -7,3 +7,4 @@ from .objs.collection import Collection
 from .objs.company import Company
 from .objs.genre import Genre
 from .objs.configuration import Configuration
+from .objs.season import Season

--- a/tmdbv3api/objs/season.py
+++ b/tmdbv3api/objs/season.py
@@ -1,0 +1,85 @@
+from tmdbv3api.tmdb import TMDb
+from tmdbv3api.as_obj import AsObj
+
+try:
+    from urllib import quote
+except ImportError:
+    from urllib.parse import quote
+
+
+class Season(TMDb):
+    _urls = {
+        'details': '/tv/%s/season/%s',
+        'changes': '/tv/season/%s/changes',
+        'account_states': '/tv/%s/season/%s/account_states',
+        'credits': '/tv/%s/season/%s/credits',
+        'external_ids': '/tv/%s/season/%s/external_ids',
+        'images': '/tv/%s/season/%s/images',
+        'videos': '/tv/%s/season/%s/videos',
+    }
+
+    def details(self, tv_id, season_num, append_to_response="append_to_response=trailers,images,casts,translations"):
+        """
+        Get the TV season details by id.
+        :param tv_id:
+        :param season_num:
+        :param append_to_response:
+        :return:
+        """
+        return AsObj(**self._call(self._urls['details'] % (str(tv_id), str(season_num)), append_to_response))
+
+    def changes(self, season_id, append_to_response="append_to_response=trailers,images,casts,translations"):
+        """
+        Get the changes for a TV season. By default only the last 24 hours are returned.
+        :param season_id:
+        :return:
+        """
+        return AsObj(**self._call(self._urls['changes'] % str(season_id), append_to_response))
+
+''' Not functional - KeyError: 'results' in line 52 of tmdb.py - I don't have time to look into I only needed details anyways
+    def account_states(self, tv_id, season_num):
+        """
+        Get all of the user ratings for the season's episodes.
+        :param tv_id:
+        :param season_num:
+        :return:
+        """
+        return self._get_obj(self._call(self._urls['account_states'] % (str(tv_id), str(season_num)), ''))
+
+    def credits(self, tv_id, season_num):
+        """
+        Get the credits for TV season.
+        :param tv_id:
+        :param season_num:
+        :return:
+        """
+        return self._get_obj(self._call(self._urls['credits'] % (str(tv_id), str(season_num)), ''))
+
+    def external_ids(self, tv_id, season_num):
+        """
+        Get the external ids for a TV season.
+        :param tv_id:
+        :param season_num:
+        :return:
+        """
+        return self._get_obj(self._call(self._urls['external_ids'] % (str(tv_id), str(season_num))))
+
+    def images(self, tv_id, season_num, page=1):
+        """
+        Get the images that belong to a TV season.
+        :param tv_id:
+        :param season_num:
+        :return:
+        """
+        return self._get_obj(self._call(self._urls['images'] % (str(tv_id), str(season_num)), 'page=' + str(page)))
+
+    def videos(self, tv_id, season_num, page=1):
+        """
+        Get the videos that have been added to a TV season.
+        :param tv_id:
+        :param season_num:
+        :param page:
+        :return:
+        """
+        return self._get_obj(self._call(self._urls['videos'] % (str(tv_id), str(season_num)), 'page=' + str(page)))
+'''


### PR DESCRIPTION
I needed information about Seasons so I added only basic support; however, I did add the tests and docs to the Readme.

Ran into a problem with most of the urls returning a KeyError 'results' from tmdb.py on line 52 and I'm not sure why. What do you reckon that's about?

But for me the details url was all I really needed anyways.
