### PR TITLE
Improve 'append_to_response' Movie/TV/Season Details

### DIFF
--- a/tmdbv3api/objs/movie.py
+++ b/tmdbv3api/objs/movie.py
@@ -35,14 +35,14 @@ class Movie(TMDb):
         """
         return self._get_obj(self._call(self._urls['keywords'] % movie_id, ''), 'keywords')
 
-    def details(self, movie_id, append_to_response="append_to_response=trailers,images,casts,translations,keywords"):
+    def details(self, movie_id, append_to_response='videos,trailers,images,casts,translations,keywords'):
         """
         Get the primary information about a movie.
         :param movie_id:
         :param append_to_response:
         :return:
         """
-        return AsObj(**self._call(self._urls['details'] % movie_id, append_to_response))
+        return AsObj(**self._call(self._urls['details'] % movie_id, 'append_to_response=' + append_to_response))
 
     def credits(self, movie_id):
         """

--- a/tmdbv3api/objs/season.py
+++ b/tmdbv3api/objs/season.py
@@ -18,7 +18,7 @@ class Season(TMDb):
         'videos': '/tv/%s/season/%s/videos',
     }
 
-    def details(self, tv_id, season_num, append_to_response="append_to_response=trailers,images,credits,translations"):
+    def details(self, tv_id, season_num, append_to_response='videos,trailers,images,credits,translations'):
         """
         Get the TV season details by id.
         :param tv_id:
@@ -26,15 +26,15 @@ class Season(TMDb):
         :param append_to_response:
         :return:
         """
-        return AsObj(**self._call(self._urls['details'] % (str(tv_id), str(season_num)), append_to_response))
+        return AsObj(**self._call(self._urls['details'] % (str(tv_id), str(season_num)), 'append_to_response=' + append_to_response))
 
-    def changes(self, season_id, append_to_response="append_to_response=trailers,images,casts,translations"):
+    def changes(self, season_id, append_to_response='videos,trailers,images,casts,translations'):
         """
         Get the changes for a TV season. By default only the last 24 hours are returned.
         :param season_id:
         :return:
         """
-        return AsObj(**self._call(self._urls['changes'] % str(season_id), append_to_response))
+        return AsObj(**self._call(self._urls['changes'] % str(season_id), 'append_to_response=' + append_to_response))
 
     def account_states(self, tv_id, season_num):
         """

--- a/tmdbv3api/objs/tv.py
+++ b/tmdbv3api/objs/tv.py
@@ -23,14 +23,14 @@ class TV(TMDb):
         'external_ids': '/tv/%s/external_ids'
     }
 
-    def details(self, show_id, append_to_response="append_to_response=trailers,images,credits,translations"):
+    def details(self, show_id, append_to_response='videos,trailers,images,credits,translations'):
         """
         Get the primary TV show details by id.
         :param show_id:
         :param append_to_response:
         :return:
         """
-        return AsObj(**self._call(self._urls['details'] % str(show_id), append_to_response))
+        return AsObj(**self._call(self._urls['details'] % str(show_id), 'append_to_response=' + append_to_response))
 
     def latest(self):
         """


### PR DESCRIPTION
- 'append_to_response' do not include 'videos' request by default, then I added it. https://developers.themoviedb.org/3/getting-started/append-to-response

- Improved input of 'append_to_response' argument in Movie, Tv and Season classes.

Before:
`movie.details(22, 'append_to_response=videos,images')`

After:
`movie.details(22, 'videos,images')`

This can break compatibility with older versions, tell me if you don't like, at least I can only include the option 'videos'. This is usefull for me. Thanks