### PR TITLE
Fix 'test_get_season_changes'

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -273,7 +273,7 @@ class TMDbTests(unittest.TestCase):
         self.assertTrue(hasattr(s, 'id'))
 
     def test_get_season_changes(self):
-        s = self.season.changes(1418, 1)
+        s = self.season.changes(1418)
         self.assertIsNotNone(s)
 
     def test_get_season_external_ids(self):


### PR DESCRIPTION
Test not working propely. 
Second argument is destinated to 'append_to_response'. A string is expected, an int object does not apply. Because of this, an exception is raised. 