### PR TITLE
Add support to Certification methods.

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2,7 +2,7 @@
 
 import unittest
 import os
-from tmdbv3api import TMDb, Movie, Discover, TV, Person, Collection, Company, Configuration, Genre, Season, List
+from tmdbv3api import TMDb, Movie, Discover, TV, Person, Collection, Company, Configuration, Genre, Season, List, Certification
 
 
 class TMDbTests(unittest.TestCase):
@@ -306,3 +306,12 @@ class TMDbTests(unittest.TestCase):
         self.assertTrue(len(list) > 10)
         self.assertTrue(hasattr(list[0], 'id'))
         self.assertTrue(hasattr(list[0], 'title'))
+
+    def test_get_certifications(self):
+        certifications = Certification()
+        movie_certifications = certifications.movie_list()
+        print(movie_certifications)
+        self.assertIsNotNone(movie_certifications)
+        tv_certifications = certifications.tv_list()
+        print(tv_certifications)
+        self.assertIsNotNone(tv_certifications)

--- a/tmdbv3api/__init__.py
+++ b/tmdbv3api/__init__.py
@@ -9,3 +9,4 @@ from .objs.genre import Genre
 from .objs.configuration import Configuration
 from .objs.season import Season
 from .objs.list import List
+from .objs.certification import Certification

--- a/tmdbv3api/objs/certification.py
+++ b/tmdbv3api/objs/certification.py
@@ -1,0 +1,15 @@
+from tmdbv3api.tmdb import TMDb
+from tmdbv3api.as_obj import AsObj
+
+
+class Certification(TMDb):
+    _urls = {
+        'movie_list': '/certification/movie/list',
+        'tv_list': '/certification/tv/list'
+    }
+
+    def movie_list(self):
+        return AsObj(**self._call(self._urls['movie_list'], ''))
+
+    def tv_list(self):
+        return AsObj(**self._call(self._urls['tv_list'], ''))


### PR DESCRIPTION
Useful if you want to retrieve the complete list of classifications for movies and TV shows to be able to select them and include them later in the search parameters.

Certification methods described here: https://developers.themoviedb.org/3/certifications

- New class => `Certification()`
- Add **movies/list** method => `Certification().movie_list`
- Add **tv/list** method => `Certification().tv_list`
- Test for both
