### PR TITLE
Fix boolean properties of class TMDb stored in os.enviroment[''].

### DIFF
--- a/tmdbv3api/tmdb.py
+++ b/tmdbv3api/tmdb.py
@@ -55,8 +55,8 @@ class TMDb(object):
 
     @property
     def wait_on_rate_limit(self):
-        if os.environ.get(self.TMDB_WAIT_ON_RATE_LIMIT) == "True": return True 
-        else: return False
+        if os.environ.get(self.TMDB_WAIT_ON_RATE_LIMIT) == "False": return False 
+        else: return True
 
     @wait_on_rate_limit.setter
     def wait_on_rate_limit(self, wait_on_rate_limit):

--- a/tmdbv3api/tmdb.py
+++ b/tmdbv3api/tmdb.py
@@ -55,7 +55,8 @@ class TMDb(object):
 
     @property
     def wait_on_rate_limit(self):
-        return bool(os.environ.get(self.TMDB_WAIT_ON_RATE_LIMIT))
+        if os.environ.get(self.TMDB_WAIT_ON_RATE_LIMIT) == "True": return True 
+        else: return False
 
     @wait_on_rate_limit.setter
     def wait_on_rate_limit(self, wait_on_rate_limit):
@@ -63,7 +64,8 @@ class TMDb(object):
 
     @property
     def debug(self):
-        return bool(os.environ.get(self.TMDB_DEBUG_ENABLED))
+        if os.environ.get(self.TMDB_DEBUG_ENABLED) == "True": return True 
+        else: return False
 
     @debug.setter
     def debug(self, debug):


### PR DESCRIPTION
I have seen that the attributes of the TMDd class that are stored in the environment variables and that are Boolean did not work correctly.

- https://stackoverflow.com/questions/715417/converting-from-a-string-to-boolean-in-python

As we can see in this reference, bool () is not able to distinguish if a String contains the word False, but it returns True if the string contains at least one character. 