### PR TITLE
Fix test_get_movie_release_dates()

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -68,7 +68,7 @@ class TMDbTests(unittest.TestCase):
         release_dates = self.movie.release_dates(111)
         self.assertIsNotNone(release_dates)
         self.assertEqual(release_dates.id, 111)
-        usa_release = release_dates.results[1]
+        usa_release = release_dates.results[13]
         self.assertEqual(usa_release.get('iso_3166_1'), 'US')
         self.assertEqual(usa_release.get('release_dates')[0].get('certification'), 'R')
 


### PR DESCRIPTION
USA release dates are now in other array position.


Test debug:

======================================================================
FAIL: test_get_movie_release_dates (tests.TMDbTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "e:\repositories\tmdbv3api\tests\tests.py", line 72, in test_get_movie_release_dates
    self.assertEqual(usa_release.get('iso_3166_1'), 'US')
AssertionError: 'AU' != 'US'
- AU
+ US