### PR TITLE
Collection: Add 'translations' method, examples and tests

### DIFF
--- a/examples/collection.py
+++ b/examples/collection.py
@@ -1,0 +1,45 @@
+from tmdbv3api import TMDb, Collection
+
+tmdb = TMDb()
+
+tmdb.api_key = ""
+tmdb.language = "en"
+
+collection = Collection()
+
+# Get collection details
+
+details = collection.details(10)
+print(details.id)
+print(details.name)
+print(details.overview)
+print(details.poster_path)
+for part in details.parts:
+    print(part["id"])
+    print(part["title"])
+
+# Get collection images 
+# If tmdb.language is 'en-US' will not work. Set tmdb.language to 'en'
+
+images = collection.images(10)
+print(images.id)
+for image in images.backdrops:
+    print(image["file_path"])
+    print(image["height"])
+    print(image["width"])
+for image in images.posters:
+    print(image["file_path"])
+    print(image["height"])
+    print(image["width"])
+
+# Get collection translations
+    
+translations = collection.translations(10)
+for translation in translations:
+    print(translation.iso_3166_1)
+    print(translation.iso_639_1)
+    print(translation.name)
+    print(translation.english_name)
+    print(translation.data["title"])
+    print(translation.data["overview"])
+    print(translation.data["homepage"])

--- a/tests/collection_test.py
+++ b/tests/collection_test.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+
+import os
+import unittest
+
+from tmdbv3api import TMDb, Collection
+
+
+class CollectionTests(unittest.TestCase):
+    def setUp(self):
+        self.tmdb = TMDb()
+        self.tmdb.api_key = os.environ["TMDB_API_KEY"]
+        self.tmdb.language = "en"
+        self.tmdb.debug = True
+        self.tmdb.wait_on_rate_limit = True
+        self.tmdb.cache = False
+        self.collection = Collection()
+         
+    def test_collection_details(self):
+        details = self.collection.details(10)
+        self.assertTrue(hasattr(details, "id"))
+        self.assertEqual(details.id, 10)
+        self.assertTrue(hasattr(details, "name"))
+        self.assertTrue(hasattr(details, "overview"))
+        self.assertTrue(hasattr(details, "poster_path"))
+        self.assertTrue(hasattr(details, "backdrop_path"))
+        self.assertTrue(hasattr(details, "parts"))
+        self.assertGreater(len(details.parts), 0)
+        for movie in details.parts:
+            self.assertIn("adult", movie)
+            self.assertIn("backdrop_path", movie)
+            self.assertIn("genre_ids", movie)
+            self.assertGreater(len(movie["genre_ids"]), 0)
+            self.assertIn("id", movie)
+            self.assertIn("original_language", movie)
+            self.assertIn("original_title", movie)
+            self.assertIn("overview", movie)
+            self.assertIn("release_date", movie)
+            self.assertIn("poster_path", movie)
+            self.assertIn("popularity", movie)
+            self.assertIn("title", movie)
+            self.assertIn("video", movie)
+            self.assertIn("vote_average", movie)
+            self.assertIn("vote_count", movie)
+
+    def test_collection_images(self):
+        images = self.collection.images(10)
+        self.assertEqual(images.id, 10)
+        self.assertTrue(hasattr(images, "backdrops"))
+        self.assertTrue(hasattr(images, "posters"))
+        self.assertGreater(len(images.backdrops), 0)
+        self.assertGreater(len(images.posters), 0)
+        for image in images.backdrops:
+            self.assertIn("aspect_ratio", image)
+            self.assertIn("file_path", image)
+            self.assertIn("height", image)
+            self.assertIn("iso_639_1", image)
+            self.assertIn("vote_average", image)
+            self.assertIn("vote_count", image)
+            self.assertIn("width", image)
+        for image in images.posters:
+            self.assertIn("aspect_ratio", image)
+            self.assertIn("file_path", image)
+            self.assertIn("height", image)
+            self.assertIn("iso_639_1", image)
+            self.assertIn("vote_average", image)
+            self.assertIn("vote_count", image)
+            self.assertIn("width", image)
+    
+    def test_collection_translations(self):
+        translations = self.collection.translations(10)
+        self.assertGreater(len(translations), 0)
+        for translation in translations:
+            self.assertTrue(hasattr(translation, "iso_3166_1"))
+            self.assertTrue(hasattr(translation, "iso_639_1"))
+            self.assertTrue(hasattr(translation, "name"))
+            self.assertTrue(hasattr(translation, "english_name"))
+            self.assertTrue(hasattr(translation, "data"))
+            self.assertIn("title", translation.data)
+            self.assertIn("overview", translation.data)
+            self.assertIn("homepage", translation.data)

--- a/tests/collection_test.py
+++ b/tests/collection_test.py
@@ -16,7 +16,7 @@ class CollectionTests(unittest.TestCase):
         self.tmdb.cache = False
         self.collection = Collection()
          
-    def test_collection_details(self):
+    def test_get_collection_details(self):
         details = self.collection.details(10)
         self.assertTrue(hasattr(details, "id"))
         self.assertEqual(details.id, 10)
@@ -43,7 +43,7 @@ class CollectionTests(unittest.TestCase):
             self.assertIn("vote_average", movie)
             self.assertIn("vote_count", movie)
 
-    def test_collection_images(self):
+    def test_get_collection_images(self):
         images = self.collection.images(10)
         self.assertEqual(images.id, 10)
         self.assertTrue(hasattr(images, "backdrops"))
@@ -67,7 +67,7 @@ class CollectionTests(unittest.TestCase):
             self.assertIn("vote_count", image)
             self.assertIn("width", image)
     
-    def test_collection_translations(self):
+    def test_get_collection_translations(self):
         translations = self.collection.translations(10)
         self.assertGreater(len(translations), 0)
         for translation in translations:

--- a/tmdbv3api/objs/collection.py
+++ b/tmdbv3api/objs/collection.py
@@ -3,7 +3,19 @@ from tmdbv3api.tmdb import TMDb
 
 
 class Collection(TMDb):
-    _urls = {"images": "/collection/%s/images", "details": "/collection/%s"}
+    _urls = {
+        "details": "/collection/%s",
+        "images": "/collection/%s/images", 
+        "translations": "/collection/%s/translations"
+        }
+
+    def details(self, collection_id):
+        """
+        Get collection details by id.
+        :param collection_id:
+        :return:
+        """
+        return AsObj(**self._call(self._urls["details"] % str(collection_id), ""))
 
     def images(self, collection_id):
         """
@@ -13,10 +25,10 @@ class Collection(TMDb):
         """
         return AsObj(**self._call(self._urls["images"] % str(collection_id), ""))
 
-    def details(self, collection_id):
+    def translations(self, collection_id):
         """
-        Get collection details by id.
+        Get the list translations for a collection by id.
         :param collection_id:
         :return:
         """
-        return AsObj(**self._call(self._urls["details"] % str(collection_id), ""))
+        return self._get_obj(self._call(self._urls["translations"] % str(collection_id), ""), "translations")


### PR DESCRIPTION
Added method for:

 - translations => Collection().translations()

Described here: https://developers.themoviedb.org/3/collections/get-collection-translations

Added tests and examples for:

 - Collection().details()
 - Collection().images()
 - Collection().translations()

Tests are in a different file because I'm working in #58 "Move integration tests for each endpoint into their own file."