### PR TITLE
Company: Add methods, examples and tests

### DIFF
--- a/examples/company.py
+++ b/examples/company.py
@@ -1,0 +1,47 @@
+from tmdbv3api import TMDb, Company
+
+tmdb = TMDb()
+
+tmdb.api_key = ""
+
+company = Company()
+
+# Company details
+
+details = company.details(1)
+print(details.description)
+print(details.headquarters)
+print(details.homepage)
+print(details.id)
+print(details.logo_path)
+print(details.name)
+print(details.origin_country)
+print(details.parent_company)
+
+# Company alternative names
+
+alternative_names = company.alternative_names(1)
+for alternative_name in alternative_names:
+    print(alternative_name.name)
+    print(alternative_name.type)
+
+# Company images
+
+images = company.images(1)
+for image in images:
+    print(image.aspect_ratio)
+    print(image.file_path)
+    print(image.height)
+    print(image.id)
+    print(image.file_type)
+    print(image.vote_average)
+    print(image.vote_count)
+    print(image.width)
+
+# Company movies
+
+movies = company.movies(1)
+for movie in movies:
+    print(movie.id)
+    print(movie.title)
+    print(movie.overview)

--- a/tests/company_test.py
+++ b/tests/company_test.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+
+import os
+import unittest
+
+from tmdbv3api import TMDb, Company
+
+
+class CompanyTests(unittest.TestCase):
+    def setUp(self):
+        self.tmdb = TMDb()
+        self.tmdb.api_key = os.environ["TMDB_API_KEY"]
+        self.tmdb.language = "en-US"
+        self.tmdb.debug = True
+        self.tmdb.wait_on_rate_limit = True
+        self.tmdb.cache = False
+        self.company = Company()
+
+    def test_get_company_details(self):
+        details = self.company.details(1)
+        self.assertTrue(hasattr(details, "description"))
+        self.assertTrue(hasattr(details, "headquarters"))
+        self.assertTrue(hasattr(details, "homepage"))
+        self.assertTrue(hasattr(details, "id"))
+        self.assertTrue(hasattr(details, "logo_path"))
+        self.assertTrue(hasattr(details, "name"))
+        self.assertTrue(hasattr(details, "origin_country"))
+        self.assertTrue(hasattr(details, "parent_company"))
+
+    def test_get_company_alternative_names(self):
+        alternative_names = self.company.alternative_names(1)
+        self.assertGreater(len(alternative_names), 0)
+        for alternative_name in alternative_names:
+            self.assertTrue(hasattr(alternative_name, "name"))
+            self.assertTrue(hasattr(alternative_name, "type"))
+
+    def test_get_company_images(self):
+        images = self.company.images(1)
+        self.assertGreater(len(images), 0)
+        for image in images:
+            self.assertTrue(hasattr(image, "aspect_ratio"))
+            self.assertTrue(hasattr(image, "file_path"))
+            self.assertTrue(hasattr(image, "height"))
+            self.assertTrue(hasattr(image, "id"))
+            self.assertTrue(hasattr(image, "file_type"))
+            self.assertTrue(hasattr(image, "vote_average"))
+            self.assertTrue(hasattr(image, "vote_count"))
+            self.assertTrue(hasattr(image, "width"))
+
+    def test_get_company_movies(self):
+        movies = self.company.movies(1)
+        self.assertGreater(len(movies), 0)
+        for movie in movies:
+            self.assertTrue(hasattr(movie, "id"))
+            self.assertTrue(hasattr(movie, "title"))
+            self.assertTrue(hasattr(movie, "overview"))

--- a/tmdbv3api/objs/company.py
+++ b/tmdbv3api/objs/company.py
@@ -3,7 +3,12 @@ from tmdbv3api.as_obj import AsObj
 
 
 class Company(TMDb):
-    _urls = {"details": "/company/%s", "movies": "/company/%s/movies"}
+    _urls = {
+        "details": "/company/%s", 
+        "alternative_names": "/company/%s/alternative_names",
+        "images": "/company/%s/images",
+        "movies": "/company/%s/movies"
+        }
 
     def details(self, company_id):
         """
@@ -12,6 +17,22 @@ class Company(TMDb):
         :return:
         """
         return AsObj(**self._call(self._urls["details"] % str(company_id), ""))
+
+    def alternative_names(self, company_id):
+        """
+        Get the alternative names of a company.
+        :param company_id: int
+        :return:
+        """
+        return self._get_obj(self._call(self._urls["alternative_names"] % str(company_id), ""))
+    
+    def images(self, company_id):
+        """
+        Get the alternative names of a company.
+        :param company_id: int
+        :return:
+        """
+        return self._get_obj(self._call(self._urls["images"] % str(company_id), ""), "logos")
 
     def movies(self, company_id):
         """


### PR DESCRIPTION
Added methods for:

 - Get alternative names => Company().alternative_names()
 - Get images => Company().images()

Described here: 
https://developers.themoviedb.org/3/companies/get-company-alternative-names
https://developers.themoviedb.org/3/companies/get-company-images

Added tests and examples for:

 - Company().details()
 - Company().alternative_names()
 - Company().images()
 - Company().movies()

The endpoint ("/company/{company_id}/movies") used by the method Company().movies() can't be found in TMDb Documentation, I don't know why but it works, then i let it.