### PR TITLE
Update AsObj

### DIFF
--- a/tests/as_obj_test.py
+++ b/tests/as_obj_test.py
@@ -1,0 +1,203 @@
+import sys
+from unittest import TestCase
+from tmdbv3api.as_obj import AsObj
+
+
+class AsObjTests(TestCase):
+    def setUp(self):
+        self.entries = {
+            'title': 'images',
+            'results': [
+                {
+                    'path': 'img/',
+                    'title': 'img1'
+                },
+                {
+                    'path': 'img/',
+                    'title': 'img2'
+                }
+            ],
+            'formats': ['.jpg', '.png'],
+            'langs': {
+                'ES' : 'es-ES', 
+                'FR': 'fr-FR'
+            }
+        }
+
+    def assert_attr(self, dict_obj):
+        self.assertIsNotNone(dict_obj)
+
+        self.assertTrue(hasattr(dict_obj, 'title'))
+        self.assertTrue(isinstance(dict_obj.title, str))
+        self.assertEqual(dict_obj.title, 'images')
+
+        self.assertTrue(hasattr(dict_obj, 'results'))
+        self.assertTrue(isinstance(dict_obj.results, list))
+        for result in dict_obj.results:
+            self.assertTrue(isinstance(result, AsObj))
+            self.assertTrue(hasattr(result, 'path'))
+            self.assertTrue(hasattr(result, 'title'))
+            self.assertTrue(isinstance(result.path, str))
+            self.assertTrue(isinstance(result.title, str))
+
+        self.assertTrue(hasattr(dict_obj, 'formats'))
+        self.assertTrue(isinstance(dict_obj.formats, list))
+        self.assertIn('.jpg', dict_obj.formats)
+        self.assertIn('.png', dict_obj.formats)
+
+        self.assertTrue(hasattr(dict_obj, 'langs'))
+        self.assertTrue(isinstance(dict_obj.langs, AsObj))
+        self.assertTrue(hasattr(dict_obj.langs, 'ES'))
+        self.assertTrue(hasattr(dict_obj.langs, 'FR'))
+        self.assertTrue(isinstance(dict_obj.langs.ES, str))
+        self.assertTrue(isinstance(dict_obj.langs.FR, str))
+        self.assertEqual(dict_obj.langs.ES, 'es-ES')
+        self.assertEqual(dict_obj.langs.FR, 'fr-FR')
+
+    def assert_dict(self, dict_obj):
+        self.assertIsNotNone(dict_obj)
+
+        self.assertIn('title', dict_obj)
+        self.assertTrue(isinstance(dict_obj['title'], str))
+        self.assertEqual(dict_obj['title'], 'images')
+
+        self.assertIn('results', dict_obj)
+        self.assertTrue(isinstance(dict_obj['results'], list))
+        for result in dict_obj['results']:
+            self.assertTrue(isinstance(result, AsObj))
+            self.assertIn('path', result)
+            self.assertIn('title', result)
+            self.assertTrue(isinstance(result['path'], str))
+            self.assertTrue(isinstance(result['title'], str))
+
+        self.assertIn('formats', dict_obj)
+        self.assertTrue(isinstance(dict_obj['formats'], list))
+        self.assertIn('.jpg', dict_obj['formats'])
+        self.assertIn('.png', dict_obj['formats'])
+
+        self.assertIn('langs', dict_obj)
+        self.assertTrue(isinstance(dict_obj['langs'], AsObj))
+        self.assertIn('ES', dict_obj['langs'])
+        self.assertIn('FR', dict_obj['langs'])
+        self.assertTrue(isinstance(dict_obj['langs']['ES'], str))
+        self.assertTrue(isinstance(dict_obj['langs']['FR'], str))
+        self.assertEqual(dict_obj['langs']['ES'], 'es-ES')
+        self.assertEqual(dict_obj['langs']['FR'], 'fr-FR')
+
+    def test_dict_obj__init__(self):
+        dict_obj = AsObj(**self.entries)
+        self.assert_attr(dict_obj)
+        self.assert_dict(dict_obj)
+        self.assert_dict(dict_obj.__dict__)
+
+    def test_dict_obj__len__(self):
+        self.assertEqual(len(AsObj(**{'a':1, 'b':2})), 2)
+        self.assertEqual(len(AsObj()), 0)
+
+    def test_dict_obj__getitem__(self):
+        dict_obj = AsObj(**self.entries)
+        self.assertEqual(dict_obj['title'], 'images')
+        self.assertEqual(dict_obj['results'][0]['path'], 'img/')
+        self.assertEqual(dict_obj['formats'][0], '.jpg')
+        self.assertEqual(dict_obj['langs']['ES'], 'es-ES')
+
+    def test_dict_obj__setitem__(self):
+        dict_obj = AsObj()
+        dict_obj['title'] = 'images'
+        dict_obj['results'] = [{'path': 'img/'}]
+        dict_obj['formats'] = ['.jpg']
+        dict_obj['langs'] = {'ES': 'es-ES'}
+        self.assertEqual(dict_obj['title'], 'images')
+        self.assertEqual(dict_obj['results'][0]['path'], 'img/')
+        self.assertEqual(dict_obj['formats'][0], '.jpg')
+        self.assertEqual(dict_obj['langs']['ES'], 'es-ES')
+
+    def test_dict_obj__delitem__(self):
+        dict_obj = AsObj(**self.entries)
+        self.assertIn('title', dict_obj)
+        del dict_obj['title']
+        self.assertNotIn('title', dict_obj)
+
+    def test_dict_obj__iter__(self):
+        try:
+            iter(AsObj(**self.entries))
+        except TypeError as e:
+            self.fail('Not iterable')
+
+    def test_dict_obj__reversed__(self):
+        if sys.version_info >= (3, 8):
+            try:
+                reversed(AsObj(**self.entries))
+            except TypeError as e:
+                self.fail('Not reverse iterable')
+
+    def test_dict_obj_clear(self):
+        dict_obj = AsObj(**self.entries)
+        dict_obj.clear()
+        self.assertEqual(len(dict_obj), 0)
+
+    def test_dict_obj_copy(self):
+        dict_obj = AsObj(**self.entries)
+        dict_obj_copy = dict_obj.copy()
+        self.assertTrue(hasattr(dict_obj_copy, 'title'))
+        self.assertEqual(dict_obj.__dict__, dict_obj_copy.__dict__)
+
+    def test_dict_obj_fromkeys(self):
+        dict_obj = AsObj().fromkeys({'a','b'})
+        self.assertEqual(len(dict_obj), 2)
+        self.assertTrue(hasattr(dict_obj, 'a'))
+        self.assertTrue(hasattr(dict_obj, 'b'))
+        for value in dict_obj.values():
+            self.assertIsNone(value)
+            
+        dict_obj = AsObj().fromkeys({'a','b'}, 1)
+        self.assertEqual(len(dict_obj), 2)
+        self.assertTrue(hasattr(dict_obj, 'a'))
+        self.assertTrue(hasattr(dict_obj, 'b'))
+        for value in dict_obj.values():
+            self.assertEqual(value, 1)
+
+    def test_dict_obj_get(self):
+        get = AsObj(**self.entries).get('title')
+        self.assertEqual(get, 'images')
+
+    def test_dict_obj_items(self):
+        items = AsObj(**self.entries).items()
+        self.assertEqual(len(items), 5)
+        self.assertIn(('title', 'images'), items)
+
+    def test_dict_obj_keys(self):
+        keys = AsObj(**self.entries).keys()
+        self.assertEqual(len(keys), 5)
+        self.assertIn('title', keys)
+
+    def test_dict_obj_pop(self):
+        dict_obj = AsObj(**self.entries)
+        pop = dict_obj.pop('title')
+        self.assertNotIn('title', dict_obj)
+        self.assertEqual(pop, 'images')
+        pop = dict_obj.pop('random', 'noexist')
+        self.assertEqual(pop, 'noexist')
+
+    def test_dict_obj_popitem(self):
+        popitem = AsObj(**self.entries).popitem()
+        self.assertIsNotNone(popitem)
+
+    def test_dict_obj_setdefault(self):
+        dict_obj = AsObj(**self.entries)
+        self.assertEqual(dict_obj.setdefault('title'), 'images')
+        self.assertEqual(dict_obj.setdefault('random', 'modnar'), 'modnar')
+
+    def test_dict_obj_update(self):
+        dict_obj = AsObj()
+        dict_obj.update(self.entries)
+        self.assertTrue(hasattr(dict_obj, 'title'))
+
+    def test_dict_obj_values(self):
+        values = AsObj(**self.entries).values()
+        self.assertEqual(len(values), 5)
+        self.assertIn('images', values)
+
+        
+        
+         

--- a/tmdbv3api/as_obj.py
+++ b/tmdbv3api/as_obj.py
@@ -42,8 +42,8 @@ class AsObj:
             return reversed(self.__dict__)
 
     if sys.version_info >= (3, 9):
-        def __class_getitem__(self, item):
-            return self.__dict__.__class_getitem__(item)
+        def __class_getitem__(self, key):
+            return self.__dict__.__class_getitem__(key)
 
         def __ior__(self, value):
             return self.__dict__.__ior__(value)

--- a/tmdbv3api/as_obj.py
+++ b/tmdbv3api/as_obj.py
@@ -1,18 +1,84 @@
 # encoding: utf-8
+import sys
 from tmdbv3api.exceptions import TMDbException
-
 
 class AsObj:
     def __init__(self, **entries):
         if "success" in entries and entries["success"] is False:
             raise TMDbException(entries["status_message"])
-        if "name" in entries:
-            self.obj_name = entries["name"]
-        elif "title" in entries:
-            self.obj_name = entries["title"]
-        else:
-            self.obj_name = "TMDB Obj"
-        self.__dict__.update(entries)
+        for key, value in entries.items():
+            if isinstance(value, list):
+                value = [AsObj(**item) if isinstance(item, dict) else item for item in value]
+            if isinstance(value, dict):
+                value = AsObj(**value)
+            if key == "name" or key == "title":
+                self.obj_name = entries[key]
+            setattr(self, key, value)
+
+    def __delitem__(self, key):
+        return delattr(self, key)
+
+    def __getitem__(self, key):
+        return getattr(self, key)
+
+    def __iter__(self):
+        return iter(self.__dict__)
+
+    def __len__(self):
+        return len(self.__dict__)
 
     def __repr__(self):
         return self.obj_name
+
+    def __setitem__(self, key, value):
+        return setattr(self, key, value)
+    
+    def __str__(self):
+        return str(self.__dict__)
+
+    if sys.version_info >= (3, 8):
+        def __reversed__(self):
+            return reversed(self.__dict__)
+
+    if sys.version_info >= (3, 9):
+        def __class_getitem__(self, item):
+            return self.__dict__.__class_getitem__(item)
+
+        def __ior__(self, value):
+            return self.__dict__.__ior__(value)
+
+        def __or__(self, value):
+            return self.__dict__.__or__(value)
+
+    def clear(self):
+        return self.__dict__.clear()
+
+    def copy(self):
+        return AsObj(**self.__dict__.copy())
+
+    def fromkeys(self, keys, value=None):
+        return AsObj(**self.__dict__.fromkeys(keys, value))
+
+    def get(self, key, value=None):
+        return self.__dict__.get(key, value)
+
+    def items(self):
+        return self.__dict__.items()
+
+    def keys(self):
+        return self.__dict__.keys()
+
+    def pop(self, key, value=None):
+        return self.__dict__.pop(key, value)
+    
+    def popitem(self):
+        return self.__dict__.popitem()
+    
+    def setdefault(self, key, value=None):
+        return self.__dict__.setdefault(key, value)
+
+    def update(self, entries):
+        return self.__dict__.update(entries)
+
+    def values(self):
+        return self.__dict__.values()

--- a/tmdbv3api/as_obj.py
+++ b/tmdbv3api/as_obj.py
@@ -2,6 +2,7 @@
 import sys
 from tmdbv3api.exceptions import TMDbException
 
+
 class AsObj:
     def __init__(self, **entries):
         if "success" in entries and entries["success"] is False:

--- a/tmdbv3api/objs/movie.py
+++ b/tmdbv3api/objs/movie.py
@@ -109,6 +109,7 @@ class Movie(TMDb):
         If you want to include a fallback language (especially useful for backdrops) you can use the include_image_language parameter. 
         This should be a comma seperated value like so: include_image_language=en,null.
         :param movie_id:
+        :param include_image_language:
         :return:
         """
         return AsObj(**self._call(self._urls['images'] % movie_id, "include_image_language=" + include_image_language))


### PR DESCRIPTION
Tired of not being clear when you access the data using the attributes of the AsObj class, or when you do so through the entries of a dict?
I have the solution: do it with anyone!

 - Now AsObj class implements all 'dict' methods, that means that is iterable.
 - All objects entered in AsObj will be processed, if a dict is found, it will become an AsObj object.

In this way you can access data by attributes or like a dict at any depth, this ensures compatibility with older versions.

Other:
 - Added tests for DictObj
 - All tests are passed

I have a question:
How about removing the attribute obj_name?
I find it unnecessary, __repr__ can still return name or title if he finds it in its attributes.

i.e.:
```
# Same result
movies.title
movies['title']

translation.data["title"]
translation["data"]["title"]
translation["data"].title
translation.data.title
translation.data.title

# You can iter:

for key in translation.data:
   print(key)
   #same result:
   print(getattr(key, translation.data))
   print(translation.data[key])

for key, value in translation.data.items():
   print(key)
   print(value)
```

Tests in my fork:
![image](https://user-images.githubusercontent.com/23286704/103483901-c18f1d80-4dea-11eb-9c46-2045fd9c6b5c.png)
