### PR TITLE
Fix Season Credits endpoint + _get_obj + test_get_keyword_details

### DIFF
--- a/tests/keyword_test.py
+++ b/tests/keyword_test.py
@@ -19,7 +19,6 @@ class KeywordTests(unittest.TestCase):
     def test_get_keyword_details(self):
         details = self.keyword.details(180547)
         self.assertTrue(hasattr(details, "name"))
-        self.assertEqual(details.name, "marvel cinematic universe")
 
     def test_get_keyword_movies(self):
         movies = self.keyword.movies(180547)

--- a/tests/season_test.py
+++ b/tests/season_test.py
@@ -45,6 +45,12 @@ class SeasonTests(unittest.TestCase):
 
     def test_get_season_credits(self):
         credits = self.season.credits(1418, 1)
-        for credit in credits:
-            self.assertTrue(hasattr(credit, "name"))
-            self.assertTrue(hasattr(credit, "character"))
+        self.assertIn("cast", credits)
+        self.assertTrue(hasattr(credits, "crew"))
+        self.assertTrue(hasattr(credits, "id"))
+        for person in credits.cast:
+            self.assertTrue(hasattr(person, "name"))
+            self.assertTrue(hasattr(person, "character"))
+        for person in credits.crew:
+            self.assertTrue(hasattr(person, "name"))
+            self.assertTrue(hasattr(person, "department"))

--- a/tmdbv3api/objs/season.py
+++ b/tmdbv3api/objs/season.py
@@ -72,7 +72,7 @@ class Season(TMDb):
         """
         return self._get_obj(
             self._call(self._urls["credits"] % (str(tv_id), str(season_num)), ""),
-            "cast",
+            None,
         )
 
     def external_ids(self, tv_id, season_num):

--- a/tmdbv3api/tmdb.py
+++ b/tmdbv3api/tmdb.py
@@ -99,16 +99,10 @@ class TMDb(object):
     def _get_obj(result, key="results", all_details=False):
         if "success" in result and result["success"] is False:
             raise TMDbException(result["status_message"])
-        arr = []
-        if key is not None:
-            [arr.append(AsObj(**res)) for res in result[key]]
-        else:
-            return result
-        if all_details is True:
-            result[key] = arr
+        if all_details is True or key is None:
             return AsObj(**result)
         else:
-            return arr
+            return [AsObj(**res) for res in result[key]]
 
     @staticmethod
     @lru_cache(maxsize=REQUEST_CACHE_MAXSIZE)


### PR DESCRIPTION
**Fix Season Changes endpoint**

I was returning only cast credits. Now is returning crew and cast.
Note that this change affect the use of this endpoint, and break the compatibility with code wrote with old versions... But I think is needed.
Other way can be simulate cast and crew endpoint, and let the credits endpoint like before, but I don't like this way.

Before:
credits[0].name

Now:
credits.cast[0].name
credits.crew[0].name

Tests fixed

**Fixed _get_obj**

Because was not returning AsObj object when key is None.
Code cleaned.

**Fix test_get_keyword_details**

Is not a good way to test because names of keywords can be updated by TMDB
