### PR TITLE
doc: fix doc of tvdb_id param of find_by_tvdb_id.

### DIFF
--- a/tmdbv3api/objs/find.py
+++ b/tmdbv3api/objs/find.py
@@ -29,7 +29,7 @@ class Find(TMDb):
     def find_by_tvdb_id(self, tvdb_id):
         """
         The find method makes it easy to search for objects in our database by a TVDB ID.
-        :param tvdb_id: int
+        :param tvdb_id: str
         :return:
         """
         return self.find(tvdb_id, "tvdb_id")


### PR DESCRIPTION
The documentation of the tvdb_id parameter from the find_by_tvdb_id function indicated int but it is str.